### PR TITLE
Replace "you|to" with "peerio" to pay homage to a suspected dead company

### DIFF
--- a/src/dict/simpsons.txt
+++ b/src/dict/simpsons.txt
@@ -4614,7 +4614,7 @@ jr
 self
 whiskey
 mac
-you|to
+peerio
 suffered
 goofy
 brother's


### PR DESCRIPTION
It is suspected that Peerio is a dead company, so former staffers are probably not watching this repository. This pull request is available as a fix to replace "you|to" with "peerio". It is also 6 characters in length, and pays homage to the company that created a great passphrase tool.

Maybe someone will swing by and merge it.